### PR TITLE
Fix asyncio loop usage in desktop app

### DIFF
--- a/Trae/desktop/app/db/database.py
+++ b/Trae/desktop/app/db/database.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 class Database:
     """Database wrapper that handles local SQLite operations with sync capabilities."""
 
-    def __init__(self, db_path: str = None, api_url: str = None, auth_token: str = None):
+    def __init__(self, db_path: str = None, api_url: str = None, auth_token: str = None, loop: Optional[asyncio.AbstractEventLoop] = None):
+        self.loop = loop
         self.db_path = db_path or settings.DB_PATH
         self.api_url = api_url or settings.API_URL
         
@@ -32,6 +33,7 @@ class Database:
             api_url=self.api_url,
             auth_token=auth_token,
             auto_sync_interval=settings.AUTO_SYNC_INTERVAL,
+            loop=self.loop,
         )
 
     def _init_db(self) -> None:

--- a/Trae/desktop/app/ui/components/status_bar.py
+++ b/Trae/desktop/app/ui/components/status_bar.py
@@ -133,7 +133,9 @@ class StatusBar(ctk.CTkFrame):
         self.status_message.configure(text="Syncing...", text_color="blue")
 
         # Start sync process
-        asyncio.create_task(self._sync_async())
+        asyncio.run_coroutine_threadsafe(
+            self._sync_async(), self.master.loop
+        )
 
     async def _sync_async(self):
         """Asynchronously perform sync operation."""

--- a/Trae/desktop/app/ui/login_window.py
+++ b/Trae/desktop/app/ui/login_window.py
@@ -114,7 +114,9 @@ class LoginWindow(ctk.CTkFrame):
 
     def check_server_connection(self):
         """Check connection to the server."""
-        asyncio.create_task(self._check_connection_async())
+        asyncio.run_coroutine_threadsafe(
+            self._check_connection_async(), self.master.loop
+        )
 
     async def _check_connection_async(self):
         """Asynchronously check connection to the server."""
@@ -149,7 +151,9 @@ class LoginWindow(ctk.CTkFrame):
         self.status_label.configure(text="")
 
         # Start login process
-        asyncio.create_task(self._login_async(username, password))
+        asyncio.run_coroutine_threadsafe(
+            self._login_async(username, password), self.master.loop
+        )
 
     async def _login_async(self, username: str, password: str):
         """Asynchronously log in to the API."""

--- a/Trae/desktop/app/ui/main_window.py
+++ b/Trae/desktop/app/ui/main_window.py
@@ -134,7 +134,9 @@ class MainWindow(ctk.CTkFrame):
     def on_logout(self):
         """Handle logout button click."""
         # Run logout process
-        asyncio.create_task(self._logout_async())
+        asyncio.run_coroutine_threadsafe(
+            self._logout_async(), self.master.loop
+        )
 
     async def _logout_async(self):
         """Asynchronously log out."""


### PR DESCRIPTION
## Summary
- run a dedicated event loop in a background thread for the desktop client
- expose the shared loop through `app.loop` and propagate to DB/sync manager
- schedule async work from GUI components with `run_coroutine_threadsafe`
- update SyncManager to use the shared loop when available

## Testing
- `python -m py_compile Trae/desktop/main.py Trae/desktop/app/app.py Trae/desktop/app/ui/login_window.py Trae/desktop/app/ui/main_window.py Trae/desktop/app/ui/components/status_bar.py Trae/desktop/app/db/database.py Trae/desktop/app/sync/sync_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684ee5e472748326a2c4e04856a70687